### PR TITLE
refractor: use localhost for MuchaUrl/GameUrl

### DIFF
--- a/TaikoLocalServer/appsettings.json
+++ b/TaikoLocalServer/appsettings.json
@@ -1,7 +1,7 @@
 {
   "UrlSettings": {
-    "MuchaUrl": "https://v402-front.mucha-prd.nbgi-amnet.jp:10122",
-    "GameUrl": "vsapi.taiko-p.jp"
+    "MuchaUrl": "https://localhost:10122",
+    "GameUrl": "localhost"
   },
   "DbFileName" : "taiko.db3",
   "Logging": {


### PR DESCRIPTION
Now that TAL2.x patches the game to connect to localhost instead of namco servers, I think we should change MuchaUrl/GameUrl to localhost

Now, this is my personal opinion but I think it should be discouraged to ping official namco servers (we have tutorials say that we need hosts file, but exposing namco server urls should probably be avoided)

TAL's url patch is still work-in-progress (as it currently has a lot of test console logs) and TRP is not perfect without hosts yet, so this PR probably needs some waiting