### PR TITLE
Fix Green title(称号) catalog extraction

### DIFF
--- a/Infrastructure/GameDataCatalog/Green/Extractor/GreenCatalogExtractor.cs
+++ b/Infrastructure/GameDataCatalog/Green/Extractor/GreenCatalogExtractor.cs
@@ -1,10 +1,11 @@
 using TaikoLocalServer.Infrastructure.GameDataCatalog.Green.Extractor.Merging;
 using TaikoLocalServer.Infrastructure.GameDataCatalog.Green.Extractor.Output;
 using TaikoLocalServer.Infrastructure.GameDataCatalog.Green.Extractor.Sources;
+using System.Text.RegularExpressions;
 
 namespace TaikoLocalServer.Infrastructure.GameDataCatalog.Green.Extractor;
 
-public static class GreenCatalogExtractor
+public static partial class GreenCatalogExtractor
 {
     public const string CostumeFileName = "green_costume_data.json";
     public const string TitleFileName = "green_title_data.json";
@@ -32,6 +33,13 @@ public static class GreenCatalogExtractor
             "reward_head_name",
             "reward_body_name");
         var titleEntries = ReadNamedPacks(options.GameDataPath, "title_name");
+        // Green game data keeps cumulative title ID ranges in filename-only .nut/.ndp
+        // sources (for example title_name_00649_00724.nut).  The legacy Green
+        // extractor only parsed files named exactly nutdatapack.ndp, which limited
+        // the generated catalog to the IDs present in the root pack (0..298 on
+        // current Green data).  Scan all title_name catalog filenames as an
+        // additional ID source, just like the older AC15 extractors do.
+        var titleIds = ReadNamedCatalogIds(options.GameDataPath, "title_name");
         var toneEntries = ReadNamedPacks(options.GameDataPath, "tone_name");
         var rewardTitleIds = File.Exists(rewardTitleFiltering)
             ? await BoostXmlReader.ReadRewardTitleIdsAsync(rewardTitleFiltering, cancellationToken)
@@ -43,7 +51,7 @@ public static class GreenCatalogExtractor
 
         var don3d = Don3dDirScanner.Scan(options.GameDataPath);
         var costumes = CostumeMerger.Merge(cosEntries, don3d, overrides);
-        var titles = TitleMerger.Merge(titleEntries, rewardTitleIds, overrides);
+        var titles = TitleMerger.Merge(titleEntries, titleIds, rewardTitleIds, overrides);
         var neiros = NeiroMerger.Merge(toneEntries, overrides);
 
         await CatalogWriter.WriteAsync(options.OutputDirectory, CostumeFileName, costumes, cancellationToken);
@@ -66,6 +74,63 @@ public static class GreenCatalogExtractor
             }
         }
     }
+
+
+    private static IReadOnlyList<uint> ReadNamedCatalogIds(string gameDataPath, string catalogDirectoryName)
+    {
+        var nutdataRoot = Path.Combine(gameDataPath, "nutdata");
+        if (!Directory.Exists(nutdataRoot))
+        {
+            return [];
+        }
+
+        return Directory.EnumerateFiles(nutdataRoot, "*", SearchOption.AllDirectories)
+            .Where(path => string.Equals(
+                Path.GetFileName(Path.GetDirectoryName(path)),
+                catalogDirectoryName,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(IsNameCatalogFile)
+            .SelectMany(path => ParseCatalogIds(Path.GetFileNameWithoutExtension(path)))
+            .Distinct()
+            .Order()
+            .ToArray();
+    }
+
+    private static bool IsNameCatalogFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return string.Equals(extension, ".nut", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(extension, ".ndp", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<uint> ParseCatalogIds(string fileName)
+    {
+        var matches = CatalogNumberRegex()
+            .Matches(fileName)
+            .Select(match => uint.Parse(match.Value))
+            .ToArray();
+
+        if (matches.Length == 0)
+        {
+            return [];
+        }
+
+        if (matches.Length >= 2)
+        {
+            var start = matches[^2];
+            var end = matches[^1];
+            if (start <= end && end - start <= 10000)
+            {
+                return Enumerable.Range((int)start, checked((int)(end - start + 1)))
+                    .Select(id => (uint)id);
+            }
+        }
+
+        return [matches[^1]];
+    }
+
+    [GeneratedRegex(@"\d+")]
+    private static partial Regex CatalogNumberRegex();
 
     private static IReadOnlyList<NdpEntry> ReadNamedPacks(string gameDataPath, params string[] catalogDirectoryNames)
     {

--- a/Infrastructure/GameDataCatalog/Green/Extractor/Merging/TitleMerger.cs
+++ b/Infrastructure/GameDataCatalog/Green/Extractor/Merging/TitleMerger.cs
@@ -9,18 +9,38 @@ public static class TitleMerger
         IEnumerable<NdpEntry> ndpEntries,
         IEnumerable<uint> rewardTitleIds,
         GreenCatalogOverrides overrides)
-    {
-        var rewardSet = rewardTitleIds.ToHashSet();
+        => Merge(ndpEntries, ndpEntries.Select(entry => entry.Id), rewardTitleIds, overrides);
 
-        return ndpEntries
-            .Select(entry =>
+    public static IReadOnlyList<Title> Merge(
+        IEnumerable<NdpEntry> ndpEntries,
+        IEnumerable<uint> discoveredTitleIds,
+        IEnumerable<uint> rewardTitleIds,
+        GreenCatalogOverrides overrides)
+    {
+        var ndpIds = ndpEntries
+            .Select(entry => entry.Id)
+            .ToHashSet();
+        var rewardSet = rewardTitleIds.ToHashSet();
+        var allIds = ndpIds
+            .Concat(discoveredTitleIds)
+            .Distinct()
+            .Order()
+            .ToArray();
+
+        return allIds
+            .Select(id =>
             {
-                overrides.Titles.TryGetValue(entry.Id, out var itemOverride);
+                overrides.Titles.TryGetValue(id, out var itemOverride);
                 var hasOverride = !string.IsNullOrWhiteSpace(itemOverride?.Name);
-                var source = rewardSet.Contains(entry.Id) ? "ndp+rewardtitlefiltering" : "ndp";
+                var source = ndpIds.Contains(id) ? "ndp" : "nut";
+                if (rewardSet.Contains(id))
+                {
+                    source += "+rewardtitlefiltering";
+                }
+
                 return new Title
                 {
-                    TitleId = entry.Id,
+                    TitleId = id,
                     TitleName = itemOverride?.Name ?? string.Empty,
                     TitleNameEN = itemOverride?.Name ?? string.Empty,
                     TitleNameCN = itemOverride?.Name ?? string.Empty,
@@ -29,9 +49,7 @@ public static class TitleMerger
                     Source = hasOverride ? $"{source}+overrides" : source
                 };
             })
-            .GroupBy(title => title.TitleId)
-            .Select(group => group.First())
-            .OrderBy(title => title.TitleId)
             .ToArray();
     }
+
 }

--- a/Tests/Green/GreenCustomizationExtractorTests.cs
+++ b/Tests/Green/GreenCustomizationExtractorTests.cs
@@ -344,6 +344,49 @@ public sealed class GreenCustomizationExtractorTests
     }
 
     [Fact]
+    public async Task GreenCatalogExtractor_ExpandsCumulativeTitleNameRanges()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var outDir = Path.Combine(root, "out");
+        Directory.CreateDirectory(Path.Combine(root, "nutdata", "cos_name"));
+        Directory.CreateDirectory(Path.Combine(root, "nutdata", "title_name"));
+        Directory.CreateDirectory(Path.Combine(root, "nutdata", "tone_name"));
+        Directory.CreateDirectory(Path.Combine(root, "nutdata", "S11100-1", "appendable", "00", "title_name"));
+
+        await File.WriteAllBytesAsync(Path.Combine(root, "nutdata", "cos_name", "nutdatapack.ndp"), BuildNdp(("cos_name_001.nut", 0, 1)));
+        await File.WriteAllBytesAsync(Path.Combine(root, "nutdata", "title_name", "nutdatapack.ndp"), BuildNdp(("title_name_000.nut", 0, 1), ("title_name_001.nut", 1, 1)));
+        await File.WriteAllBytesAsync(Path.Combine(root, "nutdata", "tone_name", "nutdatapack.ndp"), BuildNdp(("tone_name_004.nut", 0, 1)));
+        await File.WriteAllTextAsync(
+            Path.Combine(root, "nutdata", "S11100-1", "appendable", "00", "title_name", "title_name_00000_00760.nut"),
+            string.Empty);
+
+        await GreenCatalogExtractor.ExtractAsync(
+            new GreenExtractorOptions(GameDataPath: root, OutputDirectory: outDir),
+            CancellationToken.None);
+
+        var titleJson = await File.ReadAllTextAsync(Path.Combine(outDir, GreenCatalogExtractor.TitleFileName));
+        Assert.Contains("\"titleId\": 760", titleJson);
+        Assert.Contains("\"source\": \"nut\"", titleJson);
+
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public void TitleMerger_CombinesNdpAndFilenameRangeIds()
+    {
+        var titles = TitleMerger.Merge(
+            [new NdpEntry(0, "title_name_000.nut", 0, 1)],
+            [0u, 1u, 2u, 3u],
+            [3u],
+            new GreenCatalogOverrides());
+
+        Assert.Equal([0u, 1u, 2u, 3u], titles.Select(title => title.TitleId).ToArray());
+        Assert.Equal("ndp", titles[0].Source);
+        Assert.Equal("nut", titles[1].Source);
+        Assert.Equal("nut+rewardtitlefiltering", titles[3].Source);
+    }
+
+    [Fact]
     public async Task GreenCatalogExtractor_ReadsRecursiveGreenCostumeNamePacks()
     {
         var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
Green currently only uses nutdatapack.ndp entries when building the title catalog, which causes accumulated title ranges stored in files such as title_name_00000_00099.nut to be ignored.

This change parses title ID ranges from .nut / .ndp filenames under title_name directories and merges those IDs with the existing ndp-derived entries.

With Green 13.02, the catalog count increases from 299 to the expected 761 titles.